### PR TITLE
Fix for invalid directory path.

### DIFF
--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -82,6 +82,10 @@ class TokenRequest(object):
 
         if self.cache_token:
             log.debug("Caching token to '{0}'".format(self.token_path))
+
+            if os.path.isdir(self.token_path) is False:
+                raise ECSClientException('Token directory not found.')
+
             with open(self.token_path, 'w') as token_file:
                 token_file.write(self.token)
 

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -83,7 +83,8 @@ class TokenRequest(object):
         if self.cache_token:
             log.debug("Caching token to '{0}'".format(self.token_path))
 
-            if os.path.isdir(self.token_path) is False:
+            token_dir = os.path.dirname(os.path.abspath(self.token_path))
+            if os.path.isdir(token_dir) is False:
                 raise ECSClientException('Token directory not found.')
 
             with open(self.token_path, 'w') as token_file:


### PR DESCRIPTION
Using an invalid directory as the token_path creates a token leak as the token file is never create and the client continue to execute get_new_token on every call till the system runs out of tokens.