### PR TITLE
added code to only get a new logins on 401,403 or 415.

### DIFF
--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -105,8 +105,11 @@ class TokenRequest(object):
                 log.error("Invalid token")
                 return self.get_new_token()
 
+            log.debug("Token is valid")
+            return token
+
         log.debug("Token is valid")
-        return token
+        return self.get_new_token()
 
     def _get_existing_token(self):
         """

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -101,11 +101,12 @@ class TokenRequest(object):
             log.debug("Validating token")
             req = self._request(token, self.token_verification_endpoint)
 
-            if req.status_code == requests.codes.ok:
-                log.debug("Token is valid")
-                return token
+            if req.status_code == requests.codes[401] or req.status.code == requests.codes[403]:
+                log.error("Invalid token")
+                return self.get_new_token()
 
-        return self.get_new_token()
+        log.debug("Token is valid")
+        return token
 
     def _get_existing_token(self):
         """

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -104,7 +104,15 @@ class TokenRequest(object):
             log.debug("Validating token")
             req = self._request(token, self.token_verification_endpoint)
 
-            if req.status_code != 200:
+            if req.status_code == 200:
+                msg = "Token validation error.  Code returned: {0}".format(req.status_code)
+                log.debug(msg)
+                return token
+            elif req.status_code in [401, 403, 415]:
+                msg = "Token validation error.  Code returned: {0}".format(req.status_code)
+                log.warning(msg)
+                return self.get_new_token()
+            else:  # i.e. 500 or unknown raise an exception
                 msg = "Token validation error.  Code returned: {0}".format(req.status_code)
                 log.error(msg)
                 raise ECSClientException(msg)

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -101,9 +101,10 @@ class TokenRequest(object):
             log.debug("Validating token")
             req = self._request(token, self.token_verification_endpoint)
 
-            if req.status_code == 401 or req.status_code == 403:
-                log.error("Invalid token")
-                return self.get_new_token()
+            if req.status_code != 200:
+                msg = "Token validation error.  Code returned: {0}".format(req.status_code)
+                log.error(msg)
+                raise ECSClientException(msg)
 
             log.debug("Token is valid")
             return token

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -101,7 +101,7 @@ class TokenRequest(object):
             log.debug("Validating token")
             req = self._request(token, self.token_verification_endpoint)
 
-            if req.status_code == requests.codes[401] or req.status.code == requests.codes[403]:
+            if req.status_code == 401 or req.status.code == 403:
                 log.error("Invalid token")
                 return self.get_new_token()
 

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -98,6 +98,9 @@ class TokenRequest(object):
         token = self._get_existing_token()
 
         if token:
+            '''
+            If token exist very it is still a valid one, otherwise raise an exception
+            '''
             log.debug("Validating token")
             req = self._request(token, self.token_verification_endpoint)
 

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -101,7 +101,7 @@ class TokenRequest(object):
             log.debug("Validating token")
             req = self._request(token, self.token_verification_endpoint)
 
-            if req.status_code == 401 or req.status.code == 403:
+            if req.status_code == 401 or req.status_code == 403:
                 log.error("Invalid token")
                 return self.get_new_token()
 

--- a/ecsclient/common/token_request.py
+++ b/ecsclient/common/token_request.py
@@ -108,7 +108,7 @@ class TokenRequest(object):
             log.debug("Token is valid")
             return token
 
-        log.debug("Token is valid")
+        log.debug("No Token found getting new one")
         return self.get_new_token()
 
     def _get_existing_token(self):


### PR DESCRIPTION
A new token is issue when there is a /whoami that returns non 200.  The problem is that 404 for example are not invalid token and just a page that is not found.  In such case a 404 will cause the ecsclient to login again.  A long running code that produce 404s eventually exhaust all the tokens in the system.