### PR TITLE
Add ability to mock functional tests

### DIFF
--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,7 +1,9 @@
 import os
 import re
+import subprocess
 import unittest
 
+import time
 from six.moves import configparser
 
 from ecsclient.client import Client
@@ -30,7 +32,8 @@ class BaseTestCase(unittest.TestCase):
             with open(license_file) as f:
                 self.license_text = f.read()
         else:
-            self.skip_tests = True
+            self._mock_server = subprocess.Popen("tests/functional/mock_server.py")
+            time.sleep(2 / 10.0)
 
     def _get_client(self):
         return Client(

--- a/tests/functional/mock_server.py
+++ b/tests/functional/mock_server.py
@@ -1,0 +1,11 @@
+import os
+
+from wsgiref.simple_server import make_server
+from mock_server.application import Application
+
+
+if __name__ == "__main__":
+    mock_app = Application(7777, "localhost",
+                           os.path.join(os.path.dirname(__file__), "api/"),
+                           False, "application.json")
+    httpd = make_server("", 8089, mock_app).serve_forever()


### PR DESCRIPTION
Func tests now depend on a real ECS backend to be run. This PR will add the ability to use mock responses and run the func tests without configuring a real ECS endpoint.