### PR TITLE
Version bump python-requests from 2.9.1 to 2.17.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.9.1
+requests==2.17.3
 six==1.10.0
 jsonschema==2.6.0


### PR DESCRIPTION
This seems to work OK in my local lab.