### PR TITLE
Removed the 60 chars limitation and modified the error message format

### DIFF
--- a/ecsclient/common/exceptions.py
+++ b/ecsclient/common/exceptions.py
@@ -66,7 +66,7 @@ class ECSClientException(Exception):
                    http_query=parsed_url.query,
                    http_status=resp.status_code,
                    http_reason=resp.reason,
-                   http_response_content=resp.text or resp.content,
+                   http_response_content=resp.text[:8192] or resp.content[:8192],
                    http_response_headers=resp.headers)
 
     def __str__(self):

--- a/ecsclient/common/exceptions.py
+++ b/ecsclient/common/exceptions.py
@@ -47,12 +47,12 @@ class ECSClientException(Exception):
             retryable = m.get('retryable', None)
             description = m.get('description', '')
             details = m.get('details', '')
-        except:
+        except BaseException:
             pass
 
         parsed_url = urllib.parse.urlparse(resp.request.url)
         message = message or details or description or error_codes.ERROR_CODES.get(code) or '%s %s' % (
-                  resp.status_code, resp.reason)
+            resp.status_code, resp.reason)
 
         return cls(message,
                    ecs_code=code,
@@ -70,36 +70,34 @@ class ECSClientException(Exception):
                    http_response_headers=resp.headers)
 
     def __str__(self):
-        a = self.message
+        a = "\n\nError Message: %s\n" % self.message
         if self.ecs_details not in a:
-            a += ' - %s' % self.ecs_details
+            a += 'ECS_details: %s\n' % self.ecs_details
         if self.ecs_description not in a:
-            a += ' - %s' % self.ecs_description
+            a += 'ECS_description: %s\n\n' % self.ecs_description
         b = ''
         if self.http_scheme:
-            b += '%s://' % self.http_scheme
+            b += 'HTTP/S Request/Response Details:\n---------------------------------\nScheme: %s\n' % self.http_scheme
         if self.http_host:
-            b += self.http_host
+            b += "Host: %s\n" % self.http_host
         if self.http_port:
-            b += ':%s' % self.http_port
+            b += 'Port:%s\n' % self.http_port
         if self.http_path:
-            b += self.http_path
+            b += 'Path: %s\n' % self.http_path
         if self.http_query:
-            b += '?%s' % self.http_query
+            b += 'Query: %s\n' % self.http_query
+
         if self.http_status:
             if b:
-                b = '%s %s' % (b, self.http_status)
+                b += 'Response_Status: %s\n' % str(self.http_status)
             else:
-                b = str(self.http_status)
+                b = 'HTTP/S Response_Status: %s\n' % str(self.http_status)
         if self.http_reason:
             if b:
-                b = '%s %s' % (b, self.http_reason)
+                b += 'Response_Reason: %s\n' % self.http_reason
             else:
-                b = '- %s' % self.http_reason
+                b = 'HTTP/S Response_Reason: %s\n' % self.http_reason
         if self.http_response_content:
-            if len(self.http_response_content) <= 60:
-                b += '   %s' % self.http_response_content
-            else:
-                b += '  [first 60 chars of response] %s' \
-                     % self.http_response_content[:60]
-        return b and '%s: %s' % (a, b) or a
+            b += 'Response_content: %s' % self.http_response_content
+
+        return b and a + b or a


### PR DESCRIPTION
Before the change:

(venv) ECSDevKit:~/python-ecsclient # python
Python 2.7.9 (default, Dec 21 2014, 11:02:59) [GCC] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from ecsclient.client import Client
>>> client = Client('3',
...                 username='root',
...                 password='test',
...                 token_endpoint='https://10.247.142.181:4443/login',
...                 ecs_endpoint='https://10.247.142.181:4443')
>>> print(client.user_info.whoami())
No handlers could be found for logger "ecsclient.common.token_request"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "ecsclient/common/other/user_info.py", line 36, in whoami
    return self.conn.get('user/whoami')
  File "ecsclient/baseclient.py", line 117, in get
    return self._request(url, params=params)
  File "ecsclient/baseclient.py", line 163, in _request
    headers=self._fetch_headers(),
  File "ecsclient/baseclient.py", line 106, in _fetch_headers
    token = self.token if self.token else self._token_request.get_token()
  File "ecsclient/common/token_request.py", line 106, in get_token
    return self.get_new_token()
  File "ecsclient/common/token_request.py", line 75, in get_new_token
    raise ECSClientException.from_response(req, message=msg)
ecsclient.common.exceptions.ECSClientException: Invalid username or password - Access is denied due to invalid or expired credentials - Unauthorized: https://10.247.142.181:4443/login 401 Unauthorized  [first 60 chars of response] {"code":401,"description":"Unauthorized","details":"Access i



After the change:
------------------
>>> from ecsclient.client import Client
>>> client = Client('3',
...                 username='root',
...                 password='test',
...                 token_endpoint='https://10.247.142.181:4443/login',
...                 ecs_endpoint='https://10.247.142.181:4443')
>>> print(client.user_info.whoami())
No handlers could be found for logger "ecsclient.common.token_request"
ecsclient.common.exceptions.ECSClientException:

Error Message: Invalid username or password
ECS_details: Access is denied due to invalid or expired credentials
ECS_description: Unauthorized

HTTP/S Request/Response Details:
-------------------------------
Scheme: https
Host: 10.247.142.181
Port:4443
Path: /login
Response_Status: 401
Response_Reason: Unauthorized
Response_content: {"code":401,"description":"Unauthorized","details":"Access is denied due to invalid or expired credentials"}



>>> client = Client('3',
...                 username='root',
...                 password='test',
...                 ecs_endpoint='https://10.247.142.181:4443')
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "ecsclient/client.py", line 32, in Client
    return client_class(*args, **kwargs)
  File "ecsclient/v3/client.py", line 25, in __init__
    super(Client, self).__init__(*args, **kwargs)
  File "ecsclient/baseclient.py", line 54, in __init__
    raise ECSClientException("'token_endpoint' not provided and missing 'token'|'token_path'")
ecsclient.common.exceptions.ECSClientException:

Error Message: 'token_endpoint' not provided and missing 'token'|'token_path'