### PR TITLE
Allow X-EMC-Override header to add into API calls.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,9 @@ arguments:
 +-----------------------+------------+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
 | ``cache_token``       | No         | True                   | Whether to cache the token, by default this is true you should only switch this to false when you want to directly fetch a token for a user   |
 +-----------------------+------------+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
-
+| ``override_header``   | No         | None                   | Add X-EMC-Override header with the header value in API request only if it is not None
+  |
++-----------------------+------------+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
 This is how you can instantiate the ``Client`` class and use the library.
 
 .. code-block:: python
@@ -119,6 +121,20 @@ to obtain a new token on the next call. To do so, you can remove the cached toke
 .. code-block:: python
 
     client.remove_cached_token()
+
+Add X-EMC-Override: "true" header
+~~~~~~~~~~~~~~
+You can pass override_header to the client which means the user wants to add custom 
+X-EMC-Override header into API request
+
+.. code-block:: python
+
+    client = Client('3',
+                    username='someone',
+                    password='password',
+                    token_endpoint='https://192.168.1.146:4443/login',
+                    ecs_endpoint='https://192.168.1.146:4443',
+                    override_header='true')
 
 
 Supported endpoints

--- a/ecsclient/baseclient.py
+++ b/ecsclient/baseclient.py
@@ -54,6 +54,7 @@ class Client(object):
             if not (token or os.path.isfile(token_path)):
                 raise ECSClientException("'token_endpoint' not provided and missing 'token'|'token_path'")
 
+        self.override_header = override_header 
         self.username = username
         self.password = password
         self.token = token
@@ -72,7 +73,6 @@ class Client(object):
             token_path=self.token_path,
             request_timeout=self.request_timeout,
             cache_token=self.cache_token)
-        self.override_header =override_header 
 
         # Authentication
         self.authentication = Authentication(self)
@@ -106,15 +106,12 @@ class Client(object):
 
     def _fetch_headers(self):
         token = self.token if self.token else self._token_request.get_token()
-	if self.override_header == None:
-            return {'Accept': 'application/json',
-                    'Content-Type': 'application/json',
-                    'x-sds-auth-token': token}
-        else:
-            return {'Accept': 'application/json',
-                    'Content-Type': 'application/json',
-                    'x-sds-auth-token': token,
-                    'X-EMC-Override': self.override_header}
+        headers = {'Accept': 'application/json',
+                   'Content-Type': 'application/json',
+                   'x-sds-auth-token': token}
+	if self.override_header != None:
+            headers['X-EMC-Override'] = self.override_header
+        return headers
 
     def _construct_url(self, path):
         url = '{0}/{1}'.format(self.ecs_endpoint, path)

--- a/ecsclient/baseclient.py
+++ b/ecsclient/baseclient.py
@@ -23,7 +23,7 @@ class Client(object):
     def __init__(self, username=None, password=None, token=None,
                  ecs_endpoint=None, token_endpoint=None, verify_ssl=False,
                  token_path='/tmp/ecsclient.tkn',
-                 request_timeout=15.0, cache_token=True):
+                 request_timeout=15.0, cache_token=True, override_header=None):
         """
         Creates the ECSClient class that the client will directly work with
 
@@ -39,6 +39,7 @@ class Client(object):
         :param cache_token: Whether to cache the token, by default this is true
         you should only switch this to false when you want to directly fetch
         a token for a user
+        :param override_header: X-EMC-Override header value into API calls
         """
         if not ecs_endpoint:
             raise ECSClientException("Missing 'ecs_endpoint'")
@@ -71,6 +72,7 @@ class Client(object):
             token_path=self.token_path,
             request_timeout=self.request_timeout,
             cache_token=self.cache_token)
+        self.override_header =override_header 
 
         # Authentication
         self.authentication = Authentication(self)
@@ -104,9 +106,15 @@ class Client(object):
 
     def _fetch_headers(self):
         token = self.token if self.token else self._token_request.get_token()
-        return {'Accept': 'application/json',
-                'Content-Type': 'application/json',
-                'x-sds-auth-token': token}
+	if self.override_header == None:
+            return {'Accept': 'application/json',
+                    'Content-Type': 'application/json',
+                    'x-sds-auth-token': token}
+        else:
+            return {'Accept': 'application/json',
+                    'Content-Type': 'application/json',
+                    'x-sds-auth-token': token,
+                    'X-EMC-Override': self.override_header}
 
     def _construct_url(self, path):
         url = '{0}/{1}'.format(self.ecs_endpoint, path)

--- a/ecsclient/baseclient.py
+++ b/ecsclient/baseclient.py
@@ -109,7 +109,7 @@ class Client(object):
         headers = {'Accept': 'application/json',
                    'Content-Type': 'application/json',
                    'x-sds-auth-token': token}
-	if self.override_header != None:
+        if self.override_header != None:
             headers['X-EMC-Override'] = self.override_header
         return headers
 


### PR DESCRIPTION
managementGateway reverse-proxy will start blocking certain URLs and allow PUT/POST/DELETE for control service:9011 only if X-EMC-Override: true header is present. The pythonclient library must support to add this header if the user of the client is asked to do that. By default the client library should not add the new header into any API call if it is not asked by the user.
I just opened the PR for discussion, the library is not tested yet.
https://confluence.cec.lab.emc.com:8443/display/OBJSCALE/Copy+of+Overview+of+ECS+Flex+NGINX+Reverse+Proxy
